### PR TITLE
Fix: Correct Vercel build settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,6 @@
         "maxDuration": 30
       }
     },
-    "buildCommand": "echo 'No build required'",
-    "outputDirectory": ".",
-    "public": false
+    "buildCommand": "npm run build",
+    "outputDirectory": "dist"
   }


### PR DESCRIPTION
The `vercel.json` file was configured to skip the build process and deploy the root directory. This was incorrect, as the project has a build script in `package.json` that outputs the site to a `dist/` directory.

This commit updates `vercel.json` to:
- Set `buildCommand` to `npm run build`
- Set `outputDirectory` to `dist`

These changes ensure that Vercel will correctly build the project before deployment.